### PR TITLE
Fixing description, homepage and author

### DIFF
--- a/hub.yml
+++ b/hub.yml
@@ -1,9 +1,9 @@
 name: readonly-root-filesystem-psp-policy
-description: DESCRIPTION OF YOUR POLICY
-homepage: POLICY HOMEPAGE URL
+description: A Kubewarden policy that enforces root filesystem to be readonly
+homepage: https://github.com/kubewarden/readonly-root-filesystem-psp-policy
 author:
-  name: Flavio Castelli <fcastelli@suse.com>
-  homepage: https://author1.website
+  name: Kubewarden devs
+  homepage: https://github.com/kubewarden
 download:
   # Important: leave the __TAG__ around: this is automatically replaced with the value of the git tag
   registry: ghcr.io/kubewarden/policies/readonly-root-filesystem-psp-policy:__TAG__


### PR DESCRIPTION
The policy hub web page is showing the default template values in the description and homepage. This updates the `hub.yaml` file fixing these fields.