### PR TITLE
Background audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,7 +454,7 @@ dependencies = [
 
 [[package]]
 name = "readonly-root-filesystem-psp-policy"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "k8s-openapi",
  "kubewarden-policy-sdk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "readonly-root-filesystem-psp-policy"
-version = "0.1.5"
+version = "0.1.6"
 authors = ["Flavio Castelli <fcastelli@suse.com>"]
 edition = "2018"
 

--- a/artifacthub-pkg.yml
+++ b/artifacthub-pkg.yml
@@ -4,16 +4,16 @@
 #
 # This config can be saved to its default location with:
 #   kwctl scaffold artifacthub > artifacthub-pkg.yml 
-version: 0.1.5
+version: 0.1.6
 name: readonly-root-filesystem-psp
 displayName: Readonly Root Filesystem PSP
-createdAt: 2023-03-21T11:32:29.293074943Z
+createdAt: 2023-07-11T13:25:47.728299208Z
 description: A Kubewarden policy that enforces root filesystem to be readonly
 license: Apache-2.0
 homeURL: https://github.com/kubewarden/readonly-root-filesystem-psp-policy
 containersImages:
 - name: policy
-  image: ghcr.io/kubewarden/policies/readonly-root-filesystem-psp:v0.1.5
+  image: ghcr.io/kubewarden/policies/readonly-root-filesystem-psp:v0.1.6
 keywords:
 - psp
 - container
@@ -21,13 +21,13 @@ keywords:
 - volume
 links:
 - name: policy
-  url: https://github.com/kubewarden/readonly-root-filesystem-psp-policy/releases/download/v0.1.5/policy.wasm
+  url: https://github.com/kubewarden/readonly-root-filesystem-psp-policy/releases/download/v0.1.6/policy.wasm
 - name: source
   url: https://github.com/kubewarden/readonly-root-filesystem-psp-policy
 install: |
   The policy can be obtained using [`kwctl`](https://github.com/kubewarden/kwctl):
   ```console
-  kwctl pull ghcr.io/kubewarden/policies/readonly-root-filesystem-psp:v0.1.5
+  kwctl pull ghcr.io/kubewarden/policies/readonly-root-filesystem-psp:v0.1.6
   ```
 maintainers:
 - name: Kubewarden developers

--- a/metadata.yml
+++ b/metadata.yml
@@ -1,8 +1,13 @@
 rules:
-- apiGroups: [""]
-  apiVersions: ["v1"]
-  resources: ["pods"]
-  operations: ["CREATE", "UPDATE"]
+  - apiGroups:
+      - ''
+    apiVersions:
+      - v1
+    resources:
+      - pods
+    operations:
+      - CREATE
+      - UPDATE
 mutating: false
 contextAware: false
 executionMode: kubewarden-wapc
@@ -11,12 +16,14 @@ annotations:
   io.artifacthub.displayName: Readonly Root Filesystem PSP
   io.artifacthub.resources: Pod
   io.artifacthub.keywords: psp, container, filesystem, volume
+  # kubewarden specific
   io.kubewarden.policy.ociUrl: ghcr.io/kubewarden/policies/readonly-root-filesystem-psp
-  # io.kubewarden.hidden-ui: "true"
-  # rest
   io.kubewarden.policy.title: readonly-root-filesystem-psp
-  io.kubewarden.policy.description: A Kubewarden policy that enforces root filesystem to be readonly
-  io.kubewarden.policy.author: "Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>"
+  io.kubewarden.policy.description: A Kubewarden policy that enforces root filesystem
+    to be readonly
+  io.kubewarden.policy.author: Kubewarden developers <cncf-kubewarden-maintainers@lists.cncf.io>
   io.kubewarden.policy.url: https://github.com/kubewarden/readonly-root-filesystem-psp-policy
   io.kubewarden.policy.source: https://github.com/kubewarden/readonly-root-filesystem-psp-policy
   io.kubewarden.policy.license: Apache-2.0
+  io.kubewarden.policy.category: PSP
+  io.kubewarden.policy.severity: medium


### PR DESCRIPTION
## Description

Updates the metadata.yml file with the field used to enable background audit and two mode annotations used by the audit scanner report.

Related to https://github.com/kubewarden/kubewarden-controller/issues/479